### PR TITLE
Can specify onprogress in constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var through = require('through2');
 
-module.exports = function(options) {
+module.exports = function(options, onprogress) {
+	if (typeof options === 'function') return module.exports(null, options);
 	options = options || {};
 
 	var length = options.length || 0;
@@ -58,6 +59,7 @@ module.exports = function(options) {
 	});
 
 	if (drain) tr.resume();
+	if (onprogress) tr.on('progress', onprogress);
 
 	return tr;
 };


### PR DESCRIPTION
This PR allows you to specify the `on('progress')` listener in the constructor.

``` js
var p = progress(function(progress) {
  console.log('onprogress', progress);
});

// or

var p = progress({length:100}, function(progress) {
  console.log('onprogress', progress);
});
```
