### PR TITLE
added `setLength()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,12 @@ module.exports = function(options, onprogress) {
 		update.remaining = length - update.transferred;
 		tr.emit('length', length);
 	};
+	
+	// Expose `onlength()` handler as `setLength()` to support custom use cases where length
+	// is not known until after a few chunks have already been pumped, or is
+	// calculated on the fly.
+	tr.setLength = onlength;
+	
 	tr.on('pipe', function(stream) {
 		// Support http module
 		if (stream.readable && !stream.writable && stream.headers) {


### PR DESCRIPTION
Exposes the private `onlength()` handler as public `tr.setLength(someLength)` to support custom use cases where length is not known until after a few chunks have already been pumped, or is calculated on the fly.
