### PR TITLE
Fix time interval causing event floods

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(options, onprogress) {
 		update.speed = speed(delta);
 		update.eta = Math.round(update.remaining / update.speed);
 		update.runtime = parseInt((Date.now() - startTime)/1000);
-		nextUpdate += time;
+		nextUpdate = Date.now()+time;
 
 		delta = 0;
 


### PR DESCRIPTION
Fixes a bug in the time interval code that would cause 'emit's to flood in bursts. Because it was adding on the time interval to `nextUpdate` each time instead of adding it onto the current time, `nextUpdate` would slowly get more and more 'in the past' causing all future emits to flood until `nextUpdate` is incremented into the future again.