### PR TITLE
Upgrade deps to their latest versions, and fix length bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function(options, onprogress) {
 	if (typeof options === 'function') return module.exports(null, options);
 	options = options || {};
 
-	var length = options.length || 0;
+	var length = options.length || null;
 	var time = options.time || 0;
 	var drain = options.drain || false;
 	var transferred = options.transferred || 0;
@@ -57,12 +57,12 @@ module.exports = function(options, onprogress) {
 		update.remaining = length - update.transferred;
 		tr.emit('length', length);
 	};
-	
+
 	// Expose `onlength()` handler as `setLength()` to support custom use cases where length
 	// is not known until after a few chunks have already been pumped, or is
 	// calculated on the fly.
 	tr.setLength = onlength;
-	
+
 	tr.on('pipe', function(stream) {
 		if (typeof length === 'number') return;
 		// Support http module

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "through2": "~0.2.3",
-    "speedometer": "~0.1.2"
+    "speedometer": "^1.0.0",
+    "through2": "^2.0.1"
   },
   "devDependencies": {
-    "request": "~2.29.0",
-    "single-line-log": "~1.0.0",
-    "numeral": "~1.5.2"
+    "numeral": "~1.5.2",
+    "request": "^2.72.0",
+    "single-line-log": "^1.1.1"
   },
   "scripts": {
     "test": "node test/http.js && node test/request.js"


### PR DESCRIPTION
When I ran the test suite I got nothing from length, because the default length was 0 and the early return from the pipe listener was `if (typeof length === 'number') return;`

I've also updated all deps to their latest versions.
