### PR TITLE
Correct speedometer default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Sets how often progress events is emitted in ms. If omitted then defaults to emi
 
 ### speed(integer)
 
-Sets how long the speedometer needs to calculate the speed. Defaults to 5 sec.
+Sets how long the speedometer needs to calculate the speed in seconds. Defaults to 5.
 
 ### length(integer)
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function(options, onprogress) {
 	var transferred = options.transferred || 0;
 	var nextUpdate = Date.now()+time;
 	var delta = 0;
-	var speed = speedometer(options.speed || 5000);
+	var speed = speedometer(options.speed || 5);
 	var startTime = Date.now();
 
 	var update = {


### PR DESCRIPTION
The parameter of Speedometer takes in seconds (not milliseconds).