### PR TITLE
Fix incorrect check which always yields true

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = function(options, onprogress) {
 	tr.setLength = onlength;
 	
 	tr.on('pipe', function(stream) {
-		if (typeof length === 'number') return;
+		if (length > 0) return;
 		// Support http module
 		if (stream.readable && !stream.writable && stream.headers) {
 			return onlength(parseInt(stream.headers['content-length'] || 0));


### PR DESCRIPTION
I might be overlooking something trivial here, but I can't see any way where `length` is *not* a number?
It's initialized as 0, so when you pipe an HTTP stream to it, it'll still be 0, and it'll just fall back and not try to read the length from the headers. Surely this isn't how it was supposed to be? :-)